### PR TITLE
Teach user how to toggle annotations with keyboard

### DIFF
--- a/css/master.css
+++ b/css/master.css
@@ -2,6 +2,7 @@
 @import "/dist/normalize.css";
 
 @import "./app-layout.css";
+@import "./tooltip.css";
 @import "./page.css";
 @import "./parsha-picker.css";
 @import "./toggle.css";

--- a/css/toolbar.css
+++ b/css/toolbar.css
@@ -17,7 +17,8 @@
 }
 
 .annotations-toggle {
-  font-family: ShlomosemiStam
+  font-family: ShlomosemiStam;
+  position: relative;
 }
 
 .parsha-title {

--- a/css/tooltip.css
+++ b/css/tooltip.css
@@ -1,0 +1,23 @@
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  background-color: hsl(0, 0%, 20%);
+  color: white;
+  display: inline-block;
+  position: absolute;
+  top: 200%;
+  padding: 1em 1.5em;
+  border-radius: 4px;
+  font-size: 0.8em;
+  white-space: nowrap;
+  left: 50%;
+  transform: translate(-50%, 0) scale(0);
+  transform-origin: top center;
+  box-shadow: 0 0 8px -4px black;
+  font-family: sans-serif;
+}
+
+[data-tooltip]:hover::after {
+  transform: translate(-50%, 0) scale(1.0);
+  transition: transform 0.15s;
+  transition-delay: 1s;
+}

--- a/cypress/integration/app.cypress.test.js
+++ b/cypress/integration/app.cypress.test.js
@@ -124,4 +124,6 @@ describe('app', () => {
 
     cy.contains('בראשית ברא אלהים את השמים ואת הארץ')
   })
+
+  it('shows a tooltip to press the "Shift" key to toggle quickly') // can't test this because cypress does not have `cy.get('...').hover` – see https://docs.cypress.io/api/commands/hover.html#
 })

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                 <div class="toolbar-content u-page-wrap">
                     <div class="toolbar-wrapper mod-left">
                         <div class="toolbar-item">
-                            <div class="annotations-toggle" data-test-id="annotations-toggle">
+                            <div class="annotations-toggle" data-test-id="annotations-toggle" data-tooltip="Tip: Hold &quot;Shift&quot; to toggle quickly">
                                 <label class="toggle">
                                     <input data-target-id="annotations-toggle" type="checkbox" checked />
                                     <span class="toggle-state mod-off">א</span>


### PR DESCRIPTION
The implementation of "teaching" works by showing a tooltip when 
hovering the toggle.