### PR TITLE
Add schedule until 2024 for "Coming Up" section

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,2 @@
+tikkun.io
 www.tikkun.io

--- a/build/schedule.json
+++ b/build/schedule.json
@@ -233,5 +233,255 @@
     "label": "ויגש",
     "datetime": "2020-12-26",
     "date": "Dec 26"
+  },
+  {
+    "label": "ויחי",
+    "datetime": "2021-01-02",
+    "date": "Jan 2"
+  },
+  {
+    "label": "שמות",
+    "datetime": "2021-01-09",
+    "date": "Jan 9"
+  },
+  {
+    "label": "וארא",
+    "datetime": "2021-01-16",
+    "date": "Jan 16"
+  },
+  {
+    "label": "בא",
+    "datetime": "2021-01-23",
+    "date": "Jan 23"
+  },
+  {
+    "label": "בשלח",
+    "datetime": "2021-01-30",
+    "date": "Jan 30"
+  },
+  {
+    "label": "יתרו",
+    "datetime": "2021-02-06",
+    "date": "Feb 6"
+  },
+  {
+    "label": "משפטים",
+    "datetime": "2021-02-13",
+    "date": "Feb 13"
+  },
+  {
+    "label": "תרומה",
+    "datetime": "2021-02-20",
+    "date": "Feb 20"
+  },
+  {
+    "label": "תצוה",
+    "datetime": "2021-02-27",
+    "date": "Feb 27"
+  },
+  {
+    "label": "כי תשא",
+    "datetime": "2021-03-06",
+    "date": "Mar 6"
+  },
+  {
+    "label": "ויקהל – פקודי",
+    "datetime": "2021-03-13",
+    "date": "Mar 13"
+  },
+  {
+    "label": "ויקרא",
+    "datetime": "2021-03-20",
+    "date": "Mar 20"
+  },
+  {
+    "label": "צו",
+    "datetime": "2021-03-27",
+    "date": "Mar 27"
+  },
+  {
+    "label": "שמיני",
+    "datetime": "2021-04-10",
+    "date": "Apr 10"
+  },
+  {
+    "label": "תזריע – מצורע",
+    "datetime": "2021-04-17",
+    "date": "Apr 17"
+  },
+  {
+    "label": "אחרי מות – קדושים",
+    "datetime": "2021-04-24",
+    "date": "Apr 24"
+  },
+  {
+    "label": "אמור",
+    "datetime": "2021-05-01",
+    "date": "May 1"
+  },
+  {
+    "label": "בהר – בחקתי",
+    "datetime": "2021-05-08",
+    "date": "May 8"
+  },
+  {
+    "label": "במדבר",
+    "datetime": "2021-05-15",
+    "date": "May 15"
+  },
+  {
+    "label": "נשא",
+    "datetime": "2021-05-22",
+    "date": "May 22"
+  },
+  {
+    "label": "בהעלותך",
+    "datetime": "2021-05-29",
+    "date": "May 29"
+  },
+  {
+    "label": "שלח",
+    "datetime": "2021-06-05",
+    "date": "Jun 5"
+  },
+  {
+    "label": "קרח",
+    "datetime": "2021-06-12",
+    "date": "Jun 12"
+  },
+  {
+    "label": "חקת",
+    "datetime": "2021-06-19",
+    "date": "Jun 19"
+  },
+  {
+    "label": "בלק",
+    "datetime": "2021-06-26",
+    "date": "Jun 26"
+  },
+  {
+    "label": "פנחס",
+    "datetime": "2021-07-03",
+    "date": "Jul 3"
+  },
+  {
+    "label": "מטות – מסעי",
+    "datetime": "2021-07-10",
+    "date": "Jul 10"
+  },
+  {
+    "label": "דברים",
+    "datetime": "2021-07-17",
+    "date": "Jul 17"
+  },
+  {
+    "label": "ואתחנן",
+    "datetime": "2021-07-24",
+    "date": "Jul 24"
+  },
+  {
+    "label": "עקב",
+    "datetime": "2021-07-31",
+    "date": "Jul 31"
+  },
+  {
+    "label": "ראה",
+    "datetime": "2021-08-07",
+    "date": "Aug 7"
+  },
+  {
+    "label": "שופטים",
+    "datetime": "2021-08-14",
+    "date": "Aug 14"
+  },
+  {
+    "label": "כי תצא",
+    "datetime": "2021-08-21",
+    "date": "Aug 21"
+  },
+  {
+    "label": "כי תבוא",
+    "datetime": "2021-08-28",
+    "date": "Aug 28"
+  },
+  {
+    "label": "נצבים",
+    "datetime": "2021-09-04",
+    "date": "Sep 4"
+  },
+  {
+    "label": "וילך",
+    "datetime": "2021-09-11",
+    "date": "Sep 11"
+  },
+  {
+    "label": "האזינו",
+    "datetime": "2021-09-18",
+    "date": "Sep 18"
+  },
+  {
+    "label": "בראשית",
+    "datetime": "2021-10-02",
+    "date": "Oct 2"
+  },
+  {
+    "label": "נח",
+    "datetime": "2021-10-09",
+    "date": "Oct 9"
+  },
+  {
+    "label": "לך לך",
+    "datetime": "2021-10-16",
+    "date": "Oct 16"
+  },
+  {
+    "label": "וירא",
+    "datetime": "2021-10-23",
+    "date": "Oct 23"
+  },
+  {
+    "label": "חיי שרה",
+    "datetime": "2021-10-30",
+    "date": "Oct 30"
+  },
+  {
+    "label": "תולדות",
+    "datetime": "2021-11-06",
+    "date": "Nov 6"
+  },
+  {
+    "label": "ויצא",
+    "datetime": "2021-11-13",
+    "date": "Nov 13"
+  },
+  {
+    "label": "וישלח",
+    "datetime": "2021-11-20",
+    "date": "Nov 20"
+  },
+  {
+    "label": "וישב",
+    "datetime": "2021-11-27",
+    "date": "Nov 27"
+  },
+  {
+    "label": "מקץ",
+    "datetime": "2021-12-04",
+    "date": "Dec 4"
+  },
+  {
+    "label": "ויגש",
+    "datetime": "2021-12-11",
+    "date": "Dec 11"
+  },
+  {
+    "label": "ויחי",
+    "datetime": "2021-12-18",
+    "date": "Dec 18"
+  },
+  {
+    "label": "שמות",
+    "datetime": "2021-12-25",
+    "date": "Dec 25"
   }
 ]

--- a/build/schedule.json
+++ b/build/schedule.json
@@ -483,5 +483,735 @@
     "label": "שמות",
     "datetime": "2021-12-25",
     "date": "Dec 25"
+  },
+  {
+    "label": "וארא",
+    "datetime": "2022-01-01",
+    "date": "Jan 1"
+  },
+  {
+    "label": "בא",
+    "datetime": "2022-01-08",
+    "date": "Jan 8"
+  },
+  {
+    "label": "בשלח",
+    "datetime": "2022-01-15",
+    "date": "Jan 15"
+  },
+  {
+    "label": "יתרו",
+    "datetime": "2022-01-22",
+    "date": "Jan 22"
+  },
+  {
+    "label": "משפטים",
+    "datetime": "2022-01-29",
+    "date": "Jan 29"
+  },
+  {
+    "label": "תרומה",
+    "datetime": "2022-02-05",
+    "date": "Feb 5"
+  },
+  {
+    "label": "תצוה",
+    "datetime": "2022-02-12",
+    "date": "Feb 12"
+  },
+  {
+    "label": "כי תשא",
+    "datetime": "2022-02-19",
+    "date": "Feb 19"
+  },
+  {
+    "label": "ויקהל",
+    "datetime": "2022-02-26",
+    "date": "Feb 26"
+  },
+  {
+    "label": "פקודי",
+    "datetime": "2022-03-05",
+    "date": "Mar 5"
+  },
+  {
+    "label": "ויקרא",
+    "datetime": "2022-03-12",
+    "date": "Mar 12"
+  },
+  {
+    "label": "צו",
+    "datetime": "2022-03-19",
+    "date": "Mar 19"
+  },
+  {
+    "label": "שמיני",
+    "datetime": "2022-03-26",
+    "date": "Mar 26"
+  },
+  {
+    "label": "תזריע",
+    "datetime": "2022-04-02",
+    "date": "Apr 2"
+  },
+  {
+    "label": "מצורע",
+    "datetime": "2022-04-09",
+    "date": "Apr 9"
+  },
+  {
+    "label": "אחרי מות",
+    "datetime": "2022-04-30",
+    "date": "Apr 30"
+  },
+  {
+    "label": "קדושים",
+    "datetime": "2022-05-07",
+    "date": "May 7"
+  },
+  {
+    "label": "אמור",
+    "datetime": "2022-05-14",
+    "date": "May 14"
+  },
+  {
+    "label": "בהר",
+    "datetime": "2022-05-21",
+    "date": "May 21"
+  },
+  {
+    "label": "בחקתי",
+    "datetime": "2022-05-28",
+    "date": "May 28"
+  },
+  {
+    "label": "במדבר",
+    "datetime": "2022-06-04",
+    "date": "Jun 4"
+  },
+  {
+    "label": "נשא",
+    "datetime": "2022-06-11",
+    "date": "Jun 11"
+  },
+  {
+    "label": "בהעלותך",
+    "datetime": "2022-06-18",
+    "date": "Jun 18"
+  },
+  {
+    "label": "שלח",
+    "datetime": "2022-06-25",
+    "date": "Jun 25"
+  },
+  {
+    "label": "קרח",
+    "datetime": "2022-07-02",
+    "date": "Jul 2"
+  },
+  {
+    "label": "חקת",
+    "datetime": "2022-07-09",
+    "date": "Jul 9"
+  },
+  {
+    "label": "בלק",
+    "datetime": "2022-07-16",
+    "date": "Jul 16"
+  },
+  {
+    "label": "פנחס",
+    "datetime": "2022-07-23",
+    "date": "Jul 23"
+  },
+  {
+    "label": "מטות – מסעי",
+    "datetime": "2022-07-30",
+    "date": "Jul 30"
+  },
+  {
+    "label": "דברים",
+    "datetime": "2022-08-06",
+    "date": "Aug 6"
+  },
+  {
+    "label": "ואתחנן",
+    "datetime": "2022-08-13",
+    "date": "Aug 13"
+  },
+  {
+    "label": "עקב",
+    "datetime": "2022-08-20",
+    "date": "Aug 20"
+  },
+  {
+    "label": "ראה",
+    "datetime": "2022-08-27",
+    "date": "Aug 27"
+  },
+  {
+    "label": "שופטים",
+    "datetime": "2022-09-03",
+    "date": "Sep 3"
+  },
+  {
+    "label": "כי תצא",
+    "datetime": "2022-09-10",
+    "date": "Sep 10"
+  },
+  {
+    "label": "כי תבוא",
+    "datetime": "2022-09-17",
+    "date": "Sep 17"
+  },
+  {
+    "label": "נצבים",
+    "datetime": "2022-09-24",
+    "date": "Sep 24"
+  },
+  {
+    "label": "וילך",
+    "datetime": "2022-10-01",
+    "date": "Oct 1"
+  },
+  {
+    "label": "האזינו",
+    "datetime": "2022-10-08",
+    "date": "Oct 8"
+  },
+  {
+    "label": "בראשית",
+    "datetime": "2022-10-22",
+    "date": "Oct 22"
+  },
+  {
+    "label": "נח",
+    "datetime": "2022-10-29",
+    "date": "Oct 29"
+  },
+  {
+    "label": "לך לך",
+    "datetime": "2022-11-05",
+    "date": "Nov 5"
+  },
+  {
+    "label": "וירא",
+    "datetime": "2022-11-12",
+    "date": "Nov 12"
+  },
+  {
+    "label": "חיי שרה",
+    "datetime": "2022-11-19",
+    "date": "Nov 19"
+  },
+  {
+    "label": "תולדות",
+    "datetime": "2022-11-26",
+    "date": "Nov 26"
+  },
+  {
+    "label": "ויצא",
+    "datetime": "2022-12-03",
+    "date": "Dec 3"
+  },
+  {
+    "label": "וישלח",
+    "datetime": "2022-12-10",
+    "date": "Dec 10"
+  },
+  {
+    "label": "וישב",
+    "datetime": "2022-12-17",
+    "date": "Dec 17"
+  },
+  {
+    "label": "מקץ",
+    "datetime": "2022-12-24",
+    "date": "Dec 24"
+  },
+  {
+    "label": "ויגש",
+    "datetime": "2022-12-31",
+    "date": "Dec 31"
+  },
+  {
+    "label": "ויחי",
+    "datetime": "2023-01-07",
+    "date": "Jan 7"
+  },
+  {
+    "label": "שמות",
+    "datetime": "2023-01-14",
+    "date": "Jan 14"
+  },
+  {
+    "label": "וארא",
+    "datetime": "2023-01-21",
+    "date": "Jan 21"
+  },
+  {
+    "label": "בא",
+    "datetime": "2023-01-28",
+    "date": "Jan 28"
+  },
+  {
+    "label": "בשלח",
+    "datetime": "2023-02-04",
+    "date": "Feb 4"
+  },
+  {
+    "label": "יתרו",
+    "datetime": "2023-02-11",
+    "date": "Feb 11"
+  },
+  {
+    "label": "משפטים",
+    "datetime": "2023-02-18",
+    "date": "Feb 18"
+  },
+  {
+    "label": "תרומה",
+    "datetime": "2023-02-25",
+    "date": "Feb 25"
+  },
+  {
+    "label": "תצוה",
+    "datetime": "2023-03-04",
+    "date": "Mar 4"
+  },
+  {
+    "label": "כי תשא",
+    "datetime": "2023-03-11",
+    "date": "Mar 11"
+  },
+  {
+    "label": "ויקהל – פקודי",
+    "datetime": "2023-03-18",
+    "date": "Mar 18"
+  },
+  {
+    "label": "ויקרא",
+    "datetime": "2023-03-25",
+    "date": "Mar 25"
+  },
+  {
+    "label": "צו",
+    "datetime": "2023-04-01",
+    "date": "Apr 1"
+  },
+  {
+    "label": "שמיני",
+    "datetime": "2023-04-15",
+    "date": "Apr 15"
+  },
+  {
+    "label": "תזריע – מצורע",
+    "datetime": "2023-04-22",
+    "date": "Apr 22"
+  },
+  {
+    "label": "אחרי מות – קדושים",
+    "datetime": "2023-04-29",
+    "date": "Apr 29"
+  },
+  {
+    "label": "אמור",
+    "datetime": "2023-05-06",
+    "date": "May 6"
+  },
+  {
+    "label": "בהר – בחקתי",
+    "datetime": "2023-05-13",
+    "date": "May 13"
+  },
+  {
+    "label": "במדבר",
+    "datetime": "2023-05-20",
+    "date": "May 20"
+  },
+  {
+    "label": "נשא",
+    "datetime": "2023-06-03",
+    "date": "Jun 3"
+  },
+  {
+    "label": "בהעלותך",
+    "datetime": "2023-06-10",
+    "date": "Jun 10"
+  },
+  {
+    "label": "שלח",
+    "datetime": "2023-06-17",
+    "date": "Jun 17"
+  },
+  {
+    "label": "קרח",
+    "datetime": "2023-06-24",
+    "date": "Jun 24"
+  },
+  {
+    "label": "חקת – בלק",
+    "datetime": "2023-07-01",
+    "date": "Jul 1"
+  },
+  {
+    "label": "פנחס",
+    "datetime": "2023-07-08",
+    "date": "Jul 8"
+  },
+  {
+    "label": "מטות – מסעי",
+    "datetime": "2023-07-15",
+    "date": "Jul 15"
+  },
+  {
+    "label": "דברים",
+    "datetime": "2023-07-22",
+    "date": "Jul 22"
+  },
+  {
+    "label": "ואתחנן",
+    "datetime": "2023-07-29",
+    "date": "Jul 29"
+  },
+  {
+    "label": "עקב",
+    "datetime": "2023-08-05",
+    "date": "Aug 5"
+  },
+  {
+    "label": "ראה",
+    "datetime": "2023-08-12",
+    "date": "Aug 12"
+  },
+  {
+    "label": "שופטים",
+    "datetime": "2023-08-19",
+    "date": "Aug 19"
+  },
+  {
+    "label": "כי תצא",
+    "datetime": "2023-08-26",
+    "date": "Aug 26"
+  },
+  {
+    "label": "כי תבוא",
+    "datetime": "2023-09-02",
+    "date": "Sep 2"
+  },
+  {
+    "label": "נצבים – וילך",
+    "datetime": "2023-09-09",
+    "date": "Sep 9"
+  },
+  {
+    "label": "האזינו",
+    "datetime": "2023-09-23",
+    "date": "Sep 23"
+  },
+  {
+    "label": "בראשית",
+    "datetime": "2023-10-14",
+    "date": "Oct 14"
+  },
+  {
+    "label": "נח",
+    "datetime": "2023-10-21",
+    "date": "Oct 21"
+  },
+  {
+    "label": "לך לך",
+    "datetime": "2023-10-28",
+    "date": "Oct 28"
+  },
+  {
+    "label": "וירא",
+    "datetime": "2023-11-04",
+    "date": "Nov 4"
+  },
+  {
+    "label": "חיי שרה",
+    "datetime": "2023-11-11",
+    "date": "Nov 11"
+  },
+  {
+    "label": "תולדות",
+    "datetime": "2023-11-18",
+    "date": "Nov 18"
+  },
+  {
+    "label": "ויצא",
+    "datetime": "2023-11-25",
+    "date": "Nov 25"
+  },
+  {
+    "label": "וישלח",
+    "datetime": "2023-12-02",
+    "date": "Dec 2"
+  },
+  {
+    "label": "וישב",
+    "datetime": "2023-12-09",
+    "date": "Dec 9"
+  },
+  {
+    "label": "מקץ",
+    "datetime": "2023-12-16",
+    "date": "Dec 16"
+  },
+  {
+    "label": "ויגש",
+    "datetime": "2023-12-23",
+    "date": "Dec 23"
+  },
+  {
+    "label": "ויחי",
+    "datetime": "2023-12-30",
+    "date": "Dec 30"
+  },
+  {
+    "label": "שמות",
+    "datetime": "2024-01-06",
+    "date": "Jan 6"
+  },
+  {
+    "label": "וארא",
+    "datetime": "2024-01-13",
+    "date": "Jan 13"
+  },
+  {
+    "label": "בא",
+    "datetime": "2024-01-20",
+    "date": "Jan 20"
+  },
+  {
+    "label": "בשלח",
+    "datetime": "2024-01-27",
+    "date": "Jan 27"
+  },
+  {
+    "label": "יתרו",
+    "datetime": "2024-02-03",
+    "date": "Feb 3"
+  },
+  {
+    "label": "משפטים",
+    "datetime": "2024-02-10",
+    "date": "Feb 10"
+  },
+  {
+    "label": "תרומה",
+    "datetime": "2024-02-17",
+    "date": "Feb 17"
+  },
+  {
+    "label": "תצוה",
+    "datetime": "2024-02-24",
+    "date": "Feb 24"
+  },
+  {
+    "label": "כי תשא",
+    "datetime": "2024-03-02",
+    "date": "Mar 2"
+  },
+  {
+    "label": "ויקהל",
+    "datetime": "2024-03-09",
+    "date": "Mar 9"
+  },
+  {
+    "label": "פקודי",
+    "datetime": "2024-03-16",
+    "date": "Mar 16"
+  },
+  {
+    "label": "ויקרא",
+    "datetime": "2024-03-23",
+    "date": "Mar 23"
+  },
+  {
+    "label": "צו",
+    "datetime": "2024-03-30",
+    "date": "Mar 30"
+  },
+  {
+    "label": "שמיני",
+    "datetime": "2024-04-06",
+    "date": "Apr 6"
+  },
+  {
+    "label": "תזריע",
+    "datetime": "2024-04-13",
+    "date": "Apr 13"
+  },
+  {
+    "label": "מצורע",
+    "datetime": "2024-04-20",
+    "date": "Apr 20"
+  },
+  {
+    "label": "אחרי מות",
+    "datetime": "2024-05-04",
+    "date": "May 4"
+  },
+  {
+    "label": "קדושים",
+    "datetime": "2024-05-11",
+    "date": "May 11"
+  },
+  {
+    "label": "אמור",
+    "datetime": "2024-05-18",
+    "date": "May 18"
+  },
+  {
+    "label": "בהר",
+    "datetime": "2024-05-25",
+    "date": "May 25"
+  },
+  {
+    "label": "בחקתי",
+    "datetime": "2024-06-01",
+    "date": "Jun 1"
+  },
+  {
+    "label": "במדבר",
+    "datetime": "2024-06-08",
+    "date": "Jun 8"
+  },
+  {
+    "label": "נשא",
+    "datetime": "2024-06-15",
+    "date": "Jun 15"
+  },
+  {
+    "label": "בהעלותך",
+    "datetime": "2024-06-22",
+    "date": "Jun 22"
+  },
+  {
+    "label": "שלח",
+    "datetime": "2024-06-29",
+    "date": "Jun 29"
+  },
+  {
+    "label": "קרח",
+    "datetime": "2024-07-06",
+    "date": "Jul 6"
+  },
+  {
+    "label": "חקת",
+    "datetime": "2024-07-13",
+    "date": "Jul 13"
+  },
+  {
+    "label": "בלק",
+    "datetime": "2024-07-20",
+    "date": "Jul 20"
+  },
+  {
+    "label": "פנחס",
+    "datetime": "2024-07-27",
+    "date": "Jul 27"
+  },
+  {
+    "label": "מטות – מסעי",
+    "datetime": "2024-08-03",
+    "date": "Aug 3"
+  },
+  {
+    "label": "דברים",
+    "datetime": "2024-08-10",
+    "date": "Aug 10"
+  },
+  {
+    "label": "ואתחנן",
+    "datetime": "2024-08-17",
+    "date": "Aug 17"
+  },
+  {
+    "label": "עקב",
+    "datetime": "2024-08-24",
+    "date": "Aug 24"
+  },
+  {
+    "label": "ראה",
+    "datetime": "2024-08-31",
+    "date": "Aug 31"
+  },
+  {
+    "label": "שופטים",
+    "datetime": "2024-09-07",
+    "date": "Sep 7"
+  },
+  {
+    "label": "כי תצא",
+    "datetime": "2024-09-14",
+    "date": "Sep 14"
+  },
+  {
+    "label": "כי תבוא",
+    "datetime": "2024-09-21",
+    "date": "Sep 21"
+  },
+  {
+    "label": "נצבים – וילך",
+    "datetime": "2024-09-28",
+    "date": "Sep 28"
+  },
+  {
+    "label": "האזינו",
+    "datetime": "2024-10-05",
+    "date": "Oct 5"
+  },
+  {
+    "label": "בראשית",
+    "datetime": "2024-10-26",
+    "date": "Oct 26"
+  },
+  {
+    "label": "נח",
+    "datetime": "2024-11-02",
+    "date": "Nov 2"
+  },
+  {
+    "label": "לך לך",
+    "datetime": "2024-11-09",
+    "date": "Nov 9"
+  },
+  {
+    "label": "וירא",
+    "datetime": "2024-11-16",
+    "date": "Nov 16"
+  },
+  {
+    "label": "חיי שרה",
+    "datetime": "2024-11-23",
+    "date": "Nov 23"
+  },
+  {
+    "label": "תולדות",
+    "datetime": "2024-11-30",
+    "date": "Nov 30"
+  },
+  {
+    "label": "ויצא",
+    "datetime": "2024-12-07",
+    "date": "Dec 7"
+  },
+  {
+    "label": "וישלח",
+    "datetime": "2024-12-14",
+    "date": "Dec 14"
+  },
+  {
+    "label": "וישב",
+    "datetime": "2024-12-21",
+    "date": "Dec 21"
+  },
+  {
+    "label": "מקץ",
+    "datetime": "2024-12-28",
+    "date": "Dec 28"
   }
 ]


### PR DESCRIPTION
We're getting close to the end of the Gregorian year, and the "Coming Up" would break without the necessary upcoming schedule, so this should delay that problem for the next few years.