### PR TITLE
Fix: Search runs in Torah order to prevent wrong parsha labels

### DIFF
--- a/src/view-model/scroll-view-model.test.ts
+++ b/src/view-model/scroll-view-model.test.ts
@@ -39,6 +39,38 @@ test(`ignores פרשת פרה when labelling פרשת חקת`, async (t) => {
   t.regex(await renderFirstLine('2025-07-05:shacharis,main'), /פרשת חקת/)
 })
 
+test('prefers Torah order over calendar order for Mishpatim verses', async (t) => {
+  // Verses in Mishpatim (Exodus 21-24) are also read during holidays like Pesach/Sukkot.
+  // When viewing the full scroll, those verses should be labeled as Mishpatim,
+  // not as a holiday reading that appears later in the calendar year.
+  const model = ScrollViewModel.forRef(generator, {
+    scroll: 'torah',
+    b: 2,
+    c: 21,
+    v: 20,
+  })
+  const pages = await fetchPages(model, { fetchPreviousPages: false, count: 10 })
+
+  // Find lines containing Exodus 21:20 and nearby verses
+  for (const page of pages) {
+    if (page.type !== 'page') continue
+    for (const line of page.lines) {
+      // Check verses in the Exodus 21-24 range (Mishpatim)
+      const mishpatimVerses = line.verses.filter(
+        (v) => v.b === 2 && v.c >= 21 && v.c <= 24
+      )
+      if (mishpatimVerses.length && line.run) {
+        // Ensure the run is Mishpatim, not a holiday reading
+        t.regex(
+          line.run.id,
+          /mishpatim/i,
+          `Verse ${mishpatimVerses[0].b}:${mishpatimVerses[0].c}:${mishpatimVerses[0].v} should be in Mishpatim, not ${line.run.id}`
+        )
+      }
+    }
+  }
+})
+
 test('forDate on שבת', async (t) => {
   t.deepEqual(
     await renderScroll(

--- a/src/view-model/scroll-view-model.ts
+++ b/src/view-model/scroll-view-model.ts
@@ -11,7 +11,7 @@ import {
 } from '../calendar-model/model-types.ts'
 import IntegerIterator from '../integer-iterator.ts'
 import { HDate } from '@hebcal/hdate'
-import { containsRef } from '../calendar-model/ref-utils.ts'
+import { compareRefs, containsRef } from '../calendar-model/ref-utils.ts'
 import {
   fromISODateString,
   last,
@@ -239,8 +239,14 @@ export abstract class ScrollViewModel {
       const aliyot = candidateRun.aliyot.filter((a) => containsRef(a, verses))
       if (aliyot.length) return [candidateRun, aliyot]
     }
-    // TODO(later): Try the next run first?
-    for (const run of this.relevantRuns) {
+    // Search runs in Torah order, not calendar order.
+    // This ensures we match the parsha that comes first in the actual scroll,
+    // rather than a holiday reading that appears earlier in the calendar year
+    // but later in the Torah text.
+    const runsByTorahOrder = this.relevantRuns.slice().sort((a, b) => {
+      return compareRefs(a.aliyot[0].start, b.aliyot[0].start)
+    })
+    for (const run of runsByTorahOrder) {
       const aliyot = run.aliyot.filter((a) => containsRef(a, verses))
       if (aliyot.length) return [run, aliyot]
     }


### PR DESCRIPTION
## Summary
Fixes a bug where scrolling through the continuous Torah scroll would incorrectly label verses with the wrong parsha when those verses appear in both their regular parsha and in holiday readings.

## The Problem
When navigating to Mishpatim (#2-21-20) and scrolling down, the app would suddenly jump to showing Naso in the header. This happened because:

1. `FullScrollViewModel` loads ALL leining runs from the Hebrew year in **chronological calendar order**
2. Holiday readings (Pesach, Sukkot, etc.) that use verses from Mishpatim appear later in the calendar year (around when Naso is read)
3. The `findContainingAliyot` function searched runs in calendar order and returned the **first match** - which could be a holiday reading instead of the actual parsha
4. This caused the header and context to incorrectly associate the verses with a later parsha

## The Solution
Modified `findContainingAliyot()` in `scroll-view-model.ts` to sort runs by **Torah order** (book → chapter → verse) before searching for matches. This ensures that when viewing the continuous scroll, verses are always labeled with the parsha they appear in, not with holiday readings from later in the calendar year.

## Changes
- Modified `findContainingAliyot()` to sort `relevantRuns` by Torah order before searching
- Added `compareRefs` import from `ref-utils.ts`
- Added test case `prefers Torah order over calendar order for Mishpatim verses` to verify the fix

## Testing
The new test verifies that verses in Mishpatim (Exodus 21-24) are correctly labeled as Mishpatim, not as holiday readings, even when those verses are read during holidays later in the year.

Fixes the issue reported where scrolling from Mishpatim would jump to Naso on mobile.